### PR TITLE
3.7でPayout.findが動かないに対応

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 sudo: required
-dist: trusty
+dist: xenial
 addons:
   apt:
     packages:
@@ -9,6 +9,7 @@ python:
 - '2.7'
 - '3.3'
 - '3.4'
+- '3.7'
 install:
 - pip install -r requirements.txt
 - openssl version -a

--- a/README.md
+++ b/README.md
@@ -17,6 +17,11 @@ The PayPal REST SDK provides Python APIs to create, process and manage payment. 
 > **To verify that your server supports PCI compliant version of TLS, test against the PayPal sandbox environment which uses 
 TLS 1.2.
 
+## PayPal Checkout v2
+Please note that if you are integrating with PayPal Checkout, this SDK and corresponding API [v1/payments](https://developer.paypal.com/docs/api/payments/v1/) are in the process of being deprecated.
+
+We recommend that you integrate with API [v2/checkout/orders](https://developer.paypal.com/docs/api/orders/v2/) and [v2/payments](https://developer.paypal.com/docs/api/payments/v2/). Please refer to the [Checkout Python SDK](https://github.com/paypal/Checkout-Python-SDK) to continue with the integration.
+
 ## 2.0 Release Candidate!
 We're releasing a [brand new version of our SDK!](https://github.com/paypal/PayPal-python-SDK/tree/2.0-beta) 2.0 is currently at release candidate status, and represents a full refactor, with the goal of making all of our APIs extremely easy to use. 2.0 includes all of the existing APIs (except payouts), and includes the new Orders API (disputes and Marketplace coming soon). Check out the [FAQ and migration guide](https://github.com/paypal/PayPal-python-SDK/tree/2.0-beta/docs), and let us know if you have any suggestions or issues!
 

--- a/paypalrestsdk/util.py
+++ b/paypalrestsdk/util.py
@@ -31,9 +31,10 @@ def join_url(url, *paths):
         >>> util.join_url("example.com", "index.html")
         'example.com/index.html'
     """
-    for path in paths:
-        url = re.sub(r'/?$', re.sub(r'^/?', '/', path), url)
-    return url
+    result = '/'.join(chunk.strip('/') for chunk in [url] + list(paths))
+    if url.startswith('/'):
+        result = '/' + result
+    return result
 
 
 def join_url_params(url, params):

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26, py27, py33, py34, pypy
+envlist = py26, py27, py33, py34, py37, pypy
 
 [testenv]
 commands = 


### PR DESCRIPTION
Ref: https://github.com/KARASTA/karasta-server/issues/2702
Ref: https://github.com/paypal/PayPal-Python-SDK/pull/290/commits/1fed959e5bb4b762835e262bf7e421c876e0b79a

PR作成
```
$ git remote add -f idlesign https://github.com/idlesign/PayPal-Python-SDK.git
$ git merge idlesign/patch-1
```

`PayPal Checkout v2` はREADMEだけの更新
 https://github.com/paypal/PayPal-Python-SDK/commits/master の最新にも追従になってはいます。